### PR TITLE
Convert Garcon from boto2 to boto3

### DIFF
--- a/garcon/boto_legacy/decisions_handler.py
+++ b/garcon/boto_legacy/decisions_handler.py
@@ -1,0 +1,291 @@
+"""
+Class that helps to handle decision responses.
+"""
+
+
+class Decisions:
+    """
+    Use this object to build a list of decisions for a decision response.
+    Each method call will add append a new decision.  Retrieve the list
+    of decisions from the _data attribute.
+
+    """
+    def __init__(self):
+        self._data = []
+
+    def schedule_activity_task(self,
+                               activity_id,
+                               activity_type_name,
+                               activity_type_version,
+                               task_list=None,
+                               control=None,
+                               heartbeat_timeout=None,
+                               schedule_to_close_timeout=None,
+                               schedule_to_start_timeout=None,
+                               start_to_close_timeout=None,
+                               input=None):
+        """
+        Schedules an activity task.
+
+        :type activity_id: string
+        :param activity_id: The activityId of the type of the activity
+            being scheduled.
+
+        :type activity_type_name: string
+        :param activity_type_name: The name of the type of the activity
+            being scheduled.
+
+        :type activity_type_version: string
+        :param activity_type_version: The version of the type of the
+            activity being scheduled.
+
+        :type task_list: string
+        :param task_list: If set, specifies the name of the task list in
+            which to schedule the activity task. If not specified, the
+            defaultTaskList registered with the activity type will be used.
+            Note: a task list for this activity task must be specified either
+            as a default for the activity type or through this field. If
+            neither this field is set nor a default task list was specified
+            at registration time then a fault will be returned.
+        """
+        o = {}
+        o['decisionType'] = 'ScheduleActivityTask'
+        attrs = o['scheduleActivityTaskDecisionAttributes'] = {}
+        attrs['activityId'] = activity_id
+        attrs['activityType'] = {
+            'name': activity_type_name,
+            'version': activity_type_version,
+        }
+        if task_list is not None:
+            attrs['taskList'] = {'name': task_list}
+        if control is not None:
+            attrs['control'] = control
+        if heartbeat_timeout is not None:
+            attrs['heartbeatTimeout'] = heartbeat_timeout
+        if schedule_to_close_timeout is not None:
+            attrs['scheduleToCloseTimeout'] = schedule_to_close_timeout
+        if schedule_to_start_timeout is not None:
+            attrs['scheduleToStartTimeout'] = schedule_to_start_timeout
+        if start_to_close_timeout is not None:
+            attrs['startToCloseTimeout'] = start_to_close_timeout
+        if input is not None:
+            attrs['input'] = input
+        self._data.append(o)
+
+    def request_cancel_activity_task(self, activity_id):
+        """
+        Attempts to cancel a previously scheduled activity task. If
+        the activity task was scheduled but has not been assigned to a
+        worker, then it will be canceled. If the activity task was
+        already assigned to a worker, then the worker will be informed
+        that cancellation has been requested in the response to
+        RecordActivityTaskHeartbeat.
+        """
+        o = {}
+        o['decisionType'] = 'RequestCancelActivityTask'
+        attrs = o['requestCancelActivityTaskDecisionAttributes'] = {}
+        attrs['activityId'] = activity_id
+        self._data.append(o)
+
+    def record_marker(self, marker_name, details=None):
+        """
+        Records a MarkerRecorded event in the history. Markers can be
+        used for adding custom information in the history for instance
+        to let deciders know that they do not need to look at the
+        history beyond the marker event.
+        """
+        o = {}
+        o['decisionType'] = 'RecordMarker'
+        attrs = o['recordMarkerDecisionAttributes'] = {}
+        attrs['markerName'] = marker_name
+        if details is not None:
+            attrs['details'] = details
+        self._data.append(o)
+
+    def complete_workflow_execution(self, result=None):
+        """
+        Closes the workflow execution and records a WorkflowExecutionCompleted
+        event in the history
+        """
+        o = {}
+        o['decisionType'] = 'CompleteWorkflowExecution'
+        attrs = o['completeWorkflowExecutionDecisionAttributes'] = {}
+        if result is not None:
+            attrs['result'] = result
+        self._data.append(o)
+
+    def fail_workflow_execution(self, reason=None, details=None):
+        """
+        Closes the workflow execution and records a
+        WorkflowExecutionFailed event in the history.
+        """
+        o = {}
+        o['decisionType'] = 'FailWorkflowExecution'
+        attrs = o['failWorkflowExecutionDecisionAttributes'] = {}
+        if reason is not None:
+            attrs['reason'] = reason
+        if details is not None:
+            attrs['details'] = details
+        self._data.append(o)
+
+    def cancel_workflow_executions(self, details=None):
+        """
+        Closes the workflow execution and records a WorkflowExecutionCanceled
+        event in the history.
+        """
+        o = {}
+        o['decisionType'] = 'CancelWorkflowExecution'
+        attrs = o['cancelWorkflowExecutionsDecisionAttributes'] = {}
+        if details is not None:
+            attrs['details'] = details
+        self._data.append(o)
+
+    def continue_as_new_workflow_execution(
+            self,
+            child_policy=None,
+            execution_start_to_close_timeout=None,
+            input=None,
+            tag_list=None,
+            task_list=None,
+            start_to_close_timeout=None,
+            workflow_type_version=None):
+        """
+        Closes the workflow execution and starts a new workflow execution of
+        the same type using the same workflow id and a unique run Id. A
+        WorkflowExecutionContinuedAsNew event is recorded in the history.
+        """
+        o = {}
+        o['decisionType'] = 'ContinueAsNewWorkflowExecution'
+        attrs = o['continueAsNewWorkflowExecutionDecisionAttributes'] = {}
+        if child_policy is not None:
+            attrs['childPolicy'] = child_policy
+        if execution_start_to_close_timeout is not None:
+            attrs['executionStartToCloseTimeout'] = (
+                execution_start_to_close_timeout)
+        if input is not None:
+            attrs['input'] = input
+        if tag_list is not None:
+            attrs['tagList'] = tag_list
+        if task_list is not None:
+            attrs['taskList'] = {'name': task_list}
+        if start_to_close_timeout is not None:
+            attrs['taskStartToCloseTimeout'] = start_to_close_timeout
+        if workflow_type_version is not None:
+            attrs['workflowTypeVersion'] = workflow_type_version
+        self._data.append(o)
+
+    def start_timer(self,
+                    start_to_fire_timeout,
+                    timer_id,
+                    control=None):
+        """
+        Starts a timer for this workflow execution and records a TimerStarted
+        event in the history.  This timer will fire after the specified delay
+        and record a TimerFired event.
+        """
+        o = {}
+        o['decisionType'] = 'StartTimer'
+        attrs = o['startTimerDecisionAttributes'] = {}
+        attrs['startToFireTimeout'] = start_to_fire_timeout
+        attrs['timerId'] = timer_id
+        if control is not None:
+            attrs['control'] = control
+        self._data.append(o)
+
+    def cancel_timer(self, timer_id):
+        """
+        Cancels a previously started timer and records a TimerCanceled
+        event in the history.
+        """
+        o = {}
+        o['decisionType'] = 'CancelTimer'
+        attrs = o['cancelTimerDecisionAttributes'] = {}
+        attrs['timerId'] = timer_id
+        self._data.append(o)
+
+    def signal_external_workflow_execution(self,
+                                           workflow_id,
+                                           signal_name,
+                                           run_id=None,
+                                           control=None,
+                                           input=None):
+        """
+        Requests a signal to be delivered to the specified external workflow
+        execution and records a SignalExternalWorkflowExecutionInitiated
+        event in the history.
+        """
+        o = {}
+        o['decisionType'] = 'SignalExternalWorkflowExecution'
+        attrs = o['signalExternalWorkflowExecutionDecisionAttributes'] = {}
+        attrs['workflowId'] = workflow_id
+        attrs['signalName'] = signal_name
+        if run_id is not None:
+            attrs['runId'] = run_id
+        if control is not None:
+            attrs['control'] = control
+        if input is not None:
+            attrs['input'] = input
+        self._data.append(o)
+
+    def request_cancel_external_workflow_execution(self,
+                                                   workflow_id,
+                                                   control=None,
+                                                   run_id=None):
+        """
+        Requests that a request be made to cancel the specified
+        external workflow execution and records a
+        RequestCancelExternalWorkflowExecutionInitiated event in the
+        history.
+        """
+        o = {}
+        o['decisionType'] = 'RequestCancelExternalWorkflowExecution'
+        attrs = o[
+            'requestCancelExternalWorkflowExecutionDecisionAttributes'] = {}
+        attrs['workflowId'] = workflow_id
+        if control is not None:
+            attrs['control'] = control
+        if run_id is not None:
+            attrs['runId'] = run_id
+        self._data.append(o)
+
+    def start_child_workflow_execution(self,
+                                       workflow_type_name,
+                                       workflow_type_version,
+                                       workflow_id,
+                                       child_policy=None,
+                                       control=None,
+                                       execution_start_to_close_timeout=None,
+                                       input=None,
+                                       tag_list=None,
+                                       task_list=None,
+                                       task_start_to_close_timeout=None):
+        """
+        Requests that a child workflow execution be started and
+        records a StartChildWorkflowExecutionInitiated event in the
+        history.  The child workflow execution is a separate workflow
+        execution with its own history.
+        """
+        o = {}
+        o['decisionType'] = 'StartChildWorkflowExecution'
+        attrs = o['startChildWorkflowExecutionDecisionAttributes'] = {}
+        attrs['workflowType'] = {
+            'name': workflow_type_name,
+            'version': workflow_type_version,
+        }
+        attrs['workflowId'] = workflow_id
+        if child_policy is not None:
+            attrs['childPolicy'] = child_policy
+        if control is not None:
+            attrs['control'] = control
+        if execution_start_to_close_timeout is not None:
+            attrs['executionStartToCloseTimeout'] = (
+                execution_start_to_close_timeout)
+        if input is not None:
+            attrs['input'] = input
+        if tag_list is not None:
+            attrs['tagList'] = tag_list
+        if task_list is not None:
+            attrs['taskList'] = {'name': task_list}
+        if task_start_to_close_timeout is not None:
+            attrs['taskStartToCloseTimeout'] = task_start_to_close_timeout
+        self._data.append(o)

--- a/garcon/boto_legacy/medium.py
+++ b/garcon/boto_legacy/medium.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""
+Medium
+========
+
+Middle-level SWF interface. Adopted from Layer2 boto2 SWF interface.
+
+"""
+
+import json
+
+import boto3
+from botocore.exceptions import ClientError
+
+from garcon.boto_legacy import decisions_handler
+
+DEFAULT_REGION = 'us-east-1'
+DEFAULT_RETENTION_PERIOD = '30'
+DEFAULT_MAXIMUM_PAGE_SIZE = 1000
+
+
+class CommonBase:
+    """Class representing common data base of the middle-level SWF interface.
+    """
+
+    name = None
+    domain = None
+    aws_access_key_id = None
+    aws_secret_access_key = None
+    region = None
+
+    def __init__(self, **kwargs):
+        """Provide class with initial config data.
+        """
+
+        additional_kwargs = dict()
+        if 'config' in kwargs:
+            additional_kwargs['config'] = kwargs.get('config')
+            del kwargs['config']
+
+        for kwarg in kwargs:
+            setattr(self, kwarg, kwargs[kwarg])
+
+        self._swf = boto3.client(
+            service_name='swf',
+            region_name=self.region or DEFAULT_REGION,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            **additional_kwargs
+        )
+
+
+class Actor(CommonBase):
+
+    task_list = None
+    last_tasktoken = None
+
+    def run(self):
+        """To be overloaded by subclasses."""
+        raise NotImplementedError()
+
+
+class ActivityWorker(Actor):
+
+    def poll(self, task_list=None, identity=None):
+        """PollForActivityTask."""
+        additional_kwargs = dict(identity=identity) if identity else dict()
+        if task_list:
+            self.task_list = task_list
+        task = self._swf.poll_for_activity_task(
+            domain=self.domain,
+            taskList=dict(name=self.task_list),
+            **additional_kwargs)
+
+        self.last_tasktoken = task.get('taskToken')
+        return task
+
+    def heartbeat(self, task_token=None, details=''):
+        """RecordActivityTaskHeartbeat."""
+        return self._swf.record_activity_task_heartbeat(
+            taskToken=task_token or self.last_tasktoken,
+            details=details)
+
+    def complete(self, task_token=None, result=None):
+        """RespondActivityTaskCompleted."""
+        self._swf.respond_activity_task_completed(
+            taskToken=task_token or self.last_tasktoken,
+            result=json.dumps(result))
+
+    def fail(self, task_token=None, details=None, reason=None):
+        """RespondActivityTaskFailed."""
+        self._swf.respond_activity_task_failed(
+            taskToken=task_token or self.last_tasktoken,
+            reason=reason if reason else '',
+            details=details or '')
+
+    def cancel(self, task_token=None, details=None):
+        """RespondActivityTaskCanceled."""
+        if task_token is None:
+            task_token = self.last_tasktoken
+        self._swf.respond_activity_task_canceled(
+            taskToken=task_token or self.last_tasktoken,
+            details=details or '')
+
+
+class Decider(Actor):
+
+    version = None
+    activities = None
+
+    def poll(self, identity=None, task_list=None, next_page_token=None,
+            maximum_page_size=None, reverse_order=None):
+        """PollForDecisionTask."""
+
+        additional_kwargs = dict()
+        if next_page_token:
+            additional_kwargs['nextPageToken'] = next_page_token
+        if maximum_page_size:
+            additional_kwargs['maximumPageSize'] = maximum_page_size
+        if reverse_order:
+            additional_kwargs['reverseOrder'] = reverse_order
+
+        if task_list:
+            self.task_list = task_list
+
+        decision_task = self._swf.poll_for_decision_task(
+            domain=self.domain,
+            taskList=dict(name=self.task_list),
+            identity=identity or '',
+            **additional_kwargs)
+
+        self.last_tasktoken = decision_task.get('taskToken')
+        return decision_task
+
+    def complete(self, task_token=None, decisions=None, **kwargs):
+        """RespondDecisionTaskCompleted."""
+        if isinstance(decisions, decisions_handler.Decisions):
+            decisions = decisions._data
+
+        self._swf.respond_decision_task_completed(
+            taskToken=task_token or self.last_tasktoken,
+            decisions=decisions)
+
+    def register(self):
+        """Register the Workflow on SWF.
+
+        To work, SWF needs to have pre-registered the domain, the workflow,
+        and the different activities, this method takes care of this part.
+        """
+
+        registerable = []
+        registerable.append(dict(
+            method=self._swf.register_domain,
+            data=[{
+                'name': self.domain,
+                'workflowExecutionRetentionPeriodInDays':
+                    DEFAULT_RETENTION_PERIOD}]))
+
+        registerable.append(dict(
+            method=self._swf.register_workflow_type,
+            data=[{
+                'domain': self.domain,
+                'name': self.task_list,
+                'version': self.version}]))
+
+        registerable.append(dict(
+            method=self._swf.register_activity_type,
+            data=[{
+                'domain': self.domain,
+                'name': single_activity.name,
+                'version': self.version
+            } for single_activity in self.activities]))
+
+        for instance in registerable:
+            self.register_instance_with_given_method(**instance)
+
+    def register_instance_with_given_method(self, method, data):
+        """Register AWS SWF element with given specific method.
+
+        Every SWF element has it's own specific method of registration.
+        This method is independent from the type of element and uses given
+        method to register every element from given data.
+
+        Args:
+            method (callable): specific method needed to register the element.
+            data (list): list of data of elements needed to be registered.
+        """
+
+        for entity in data:
+            try:
+                method(**entity)
+            except ClientError as e:
+                print(e)

--- a/garcon/context.py
+++ b/garcon/context.py
@@ -100,5 +100,5 @@ class ExecutionContext:
         attributes = activity_event['activityTaskCompletedEventAttributes']
         result = attributes.get('result')
 
-        if result:
+        if result and result != '"{}"':
             self.current.update(json.loads(result))

--- a/garcon/decider.py
+++ b/garcon/decider.py
@@ -7,18 +7,17 @@ The decider worker is focused on orchestrating which activity needs to be
 executed and when based on the flow procided.
 """
 
-from boto.swf.exceptions import SWFDomainAlreadyExistsError
-from boto.swf.exceptions import SWFTypeAlreadyExistsError
-import boto.swf.layer2 as swf
 import functools
 import json
 
 from garcon import activity
 from garcon import event
 from garcon import log
+from garcon.boto_legacy import decisions_handler
+from garcon.boto_legacy import medium
 
 
-class DeciderWorker(swf.Decider, log.GarconLogger):
+class DeciderWorker(medium.Decider, log.GarconLogger):
 
     def __init__(self, flow, register=True):
         """Initialize the Decider Worker.
@@ -62,7 +61,6 @@ class DeciderWorker(swf.Decider, log.GarconLogger):
         # Remove all the events that are related to decisions and only.
         return [e for e in events if not e['eventType'].startswith('Decision')]
 
-
     def get_activity_states(self, history):
         """Get the activity states from the history.
 
@@ -77,37 +75,6 @@ class DeciderWorker(swf.Decider, log.GarconLogger):
         """
 
         return event.activity_states_from_events(history)
-
-    def register(self):
-        """Register the Workflow on SWF.
-
-        To work, SWF needs to have pre-registered the domain, the workflow,
-        and the different activities, this method takes care of this part.
-        """
-
-        registerables = []
-        registerables.append(swf.Domain(name=self.domain))
-        registerables.append(swf.WorkflowType(
-            domain=self.domain,
-            name=self.task_list,
-            version=self.version,
-            task_list=self.task_list))
-
-        for current_activity in self.activities:
-            registerables.append(
-                swf.ActivityType(
-                    domain=self.domain,
-                    name=current_activity.name,
-                    version=self.version,
-                    task_list=current_activity.task_list))
-
-        for swf_entity in registerables:
-            try:
-                swf_entity.register()
-            except (SWFDomainAlreadyExistsError, SWFTypeAlreadyExistsError):
-                print(
-                    swf_entity.__class__.__name__, swf_entity.name,
-                    'already exists')
 
     def create_decisions_from_flow(self, decisions, activity_states, context):
         """Create the decisions from the flow.
@@ -219,6 +186,7 @@ class DeciderWorker(swf.Decider, log.GarconLogger):
             self.logger.error(error, exc_info=True)
             return True
 
+        self.last_token = poll.get('taskToken')
         custom_decider = getattr(self.flow, 'decider', None)
 
         if 'events' not in poll:
@@ -229,7 +197,7 @@ class DeciderWorker(swf.Decider, log.GarconLogger):
         current_context = event.get_current_context(history)
         current_context.set_workflow_execution_info(poll, self.domain)
 
-        decisions = swf.Layer1Decisions()
+        decisions = decisions_handler.Decisions()
         if not custom_decider:
             self.create_decisions_from_flow(
                 decisions, activity_states, current_context)

--- a/garcon/utils.py
+++ b/garcon/utils.py
@@ -29,38 +29,3 @@ def create_dictionary_key(dictionary):
         for (key, val) in sorted_dict])
 
     return hashlib.sha1(key_parts.encode('utf-8')).hexdigest()
-
-def non_throttle_error(swf_response_error):
-    """Activity Runner.
-
-    Determine whether SWF Exception was a throttle or a different error.
-
-    Args:
-        error: boto.exception.SWFResponseError instance.
-    Return:
-        bool: True if SWFResponseError was a throttle, False otherwise.
-    """
-
-    return swf_response_error.error_code != 'ThrottlingException'
-
-def throttle_backoff_handler(details):
-    """Callback to be used when a throttle backoff is invoked.
-
-    For more details see: https://github.com/litl/backoff/#event-handlers
-
-    Args:
-        dictionary (dict): Details of the backoff invocation. Valid keys
-            include:
-                target: reference to the function or method being invoked.
-                args: positional arguments to func.
-                kwargs: keyword arguments to func.
-                tries: number of invocation tries so far.
-                wait: seconds to wait (on_backoff handler only).
-                value: value triggering backoff (on_predicate decorator only).
-    """
-
-    activity = details['args'][0]
-    activity.logger.info(
-        'Throttle Exception occurred on try {}. '
-        'Sleeping for {} seconds'.format(
-            details['tries'], details['wait']))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-backoff==1.4.3
-boto==2.35.1
+boto3==1.7.50
 pytest-cov==1.8.1
 pytest==2.6.4
 python-coveralls==2.4.3

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,7 +6,6 @@ except:
 import boto.swf.layer2 as swf
 
 from garcon import context
-from tests.fixtures import decider as decider_events
 
 
 def mock(monkeypatch):
@@ -35,6 +34,7 @@ def test_context_creation_with_events(monkeypatch):
 
     current_context = context.ExecutionContext(poll.history.get('events'))
     assert current_context.current == {'k': 'v'}
+
 
 def test_get_workflow_execution_info(monkeypatch):
     """Check that the workflow execution info are properly extracted

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -3,19 +3,20 @@ try:
     from unittest.mock import MagicMock
 except:
     from mock import MagicMock
-import boto.swf.layer2 as swf
+# import boto.swf.layer2 as swf
 import json
 import pytest
 
-from garcon import decider
 from garcon import activity
+from garcon import decider
+from garcon.boto_legacy import medium
+
 from tests.fixtures import decider as decider_events
 
-
 def mock(monkeypatch):
-    for base in [swf.Decider, swf.WorkflowType, swf.ActivityType, swf.Domain]:
+    for base in [medium.Decider, medium.ActivityWorker]:
         monkeypatch.setattr(base, '__init__', MagicMock(return_value=None))
-        if base is not swf.Decider:
+        if base is medium.Decider:
             monkeypatch.setattr(base, 'register', MagicMock())
 
 

--- a/tests/test_decisions_handler.py
+++ b/tests/test_decisions_handler.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+from __future__ import print_function
+try:
+    from unittest.mock import MagicMock
+except:
+    from mock import MagicMock
+import pytest
+
+from garcon.boto_legacy import decisions_handler
+
+
+@pytest.fixture
+def vaild_continue_workflow_response():
+    return {
+        'decisionType': 'ContinueAsNewWorkflowExecution',
+        'continueAsNewWorkflowExecutionDecisionAttributes': {
+            'childPolicy': 'TERMINATE',
+            'executionStartToCloseTimeout': '10',
+            'input': 'input',
+            'tagList': ['t1', 't2'],
+            'taskList': {'name': 'tasklist'},
+            'taskStartToCloseTimeout': '20',
+            'workflowTypeVersion': 'v2',
+        }
+    }
+
+
+def test_continue_as_new_workflow_execution(vaild_continue_workflow_response):
+    data = vaild_continue_workflow_response
+    d = decisions_handler.Decisions()
+
+    d.continue_as_new_workflow_execution(
+        child_policy='TERMINATE',
+        execution_start_to_close_timeout='10',
+        input='input',
+        tag_list=['t1', 't2'],
+        task_list='tasklist',
+        start_to_close_timeout='20',
+        workflow_type_version='v2'
+    )
+    assert d._data[0] == data

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -1,0 +1,282 @@
+from __future__ import absolute_import
+from __future__ import print_function
+try:
+    from unittest.mock import MagicMock
+except:
+    from mock import MagicMock
+import json
+import pytest
+
+import boto3
+from botocore.exceptions import ClientError
+
+from garcon.boto_legacy import medium
+
+
+@pytest.fixture
+def common_base_valid_parameters():
+    return {
+        'name': 'name',
+        'domain': 'domain',
+        'aws_access_key_id': 'id',
+        'aws_secret_access_key': 'key',
+        'region': 'region',
+    }
+
+@pytest.fixture
+def poll_for_activity_task_response():
+    return {
+        'activityId': 'SomeActivity-1379020713',
+        'activityType': {'name': 'SomeActivity', 'version': '1.0'},
+        'startedEventId': 6,
+        'taskToken': '',
+        'workflowExecution': {
+            'runId': '12T026NzGK5c4eMti06N9O3GHFuTDaNyA+8LFtoDkAwfE=',
+            'workflowId': 'MyWorkflow-1.0-1379020705'}}
+
+@pytest.fixture
+def poll_for_decision_task_response():
+    return {
+        'events': [
+            {
+                'eventId': 1,
+                'eventTimestamp': 1379019427.953,
+                'eventType': 'WorkflowExecutionStarted',
+                'workflowExecutionStartedEventAttributes': {
+                'childPolicy': 'TERMINATE',
+                'executionStartToCloseTimeout': '3600',
+                'parentInitiatedEventId': 0,
+                'taskList': {'name': 'test_list'},
+                'taskStartToCloseTimeout': '123',
+                'workflowType': {'name': 'test_workflow_name',
+                'version': 'v1'}}
+            },
+            {'decisionTaskScheduledEventAttributes':
+                 {
+                     'startToCloseTimeout': '123',
+                     'taskList': {'name': 'test_list'}
+                 },
+                 'eventId': 2,
+                 'eventTimestamp': 1379019427.953,
+                 'eventType': 'DecisionTaskScheduled'
+            },
+            {
+                'decisionTaskStartedEventAttributes': {'scheduledEventId': 2},
+                 'eventId': 3, 'eventTimestamp': 1379019495.585,
+                 'eventType': 'DecisionTaskStarted'
+            }
+        ],
+         'previousStartedEventId': 0, 'startedEventId': 3,
+         'taskToken': '',
+         'workflowExecution': {'runId': 'fwr243dsa324132jmflkfu0943tr09=',
+                   'workflowId': 'test_workflow_name-v1-1379019427'},
+         'workflowType': {'name': 'test_workflow_name', 'version': 'v1'}
+    }
+
+@pytest.fixture
+def activity_object():
+    class ActvitityDummy:
+        name = 'test_activity_name'
+
+    return ActvitityDummy()
+
+
+def test_common_base(common_base_valid_parameters):
+    """Test common data base class.
+    """
+
+    boto3.client = MagicMock()
+
+    base = medium.CommonBase()
+    assert base.name == None
+    assert base.domain == None
+    assert base.aws_access_key_id == None
+    assert base.aws_secret_access_key == None
+    assert base.region == None
+
+    base = medium.CommonBase(
+        name='name',
+        domain='domain',
+        aws_access_key_id='id',
+        aws_secret_access_key='key',
+        region='region')
+    assert base.name == common_base_valid_parameters['name']
+    assert base.domain == common_base_valid_parameters['domain']
+    assert base.aws_access_key_id == common_base_valid_parameters[
+        'aws_access_key_id']
+    assert base.aws_secret_access_key == common_base_valid_parameters[
+        'aws_secret_access_key']
+    assert base.region == common_base_valid_parameters['region']
+
+
+def test_activity_class(poll_for_activity_task_response):
+    """Test Activity Worker class.
+    """
+
+    boto3.client = MagicMock()
+
+    worker = medium.ActivityWorker()
+    assert worker.name == None
+    assert worker.domain == None
+    assert worker.aws_access_key_id == None
+    assert worker.aws_secret_access_key == None
+    assert worker.region == None
+    pass
+
+    worker = medium.ActivityWorker(
+        name='test_name',
+        domain='test_domain',
+        task_list='test_task_list')
+    assert worker.name == 'test_name'
+    assert worker.domain == 'test_domain'
+    assert worker.task_list == 'test_task_list'
+
+    task_token = 'worker_task_token'
+    input_data = poll_for_activity_task_response
+    input_data['taskToken'] = task_token
+    worker._swf.poll_for_activity_task.return_value = input_data
+
+    worker.poll()
+
+    worker.cancel(details='Cancelling!')
+    worker.complete(result='Done!')
+    worker.fail(reason='Failure!')
+    worker.heartbeat()
+
+    worker._swf.respond_activity_task_canceled.assert_called_with(
+        taskToken=task_token, details='Cancelling!')
+    worker._swf.respond_activity_task_completed.assert_called_with(
+        taskToken=task_token, result=json.dumps('Done!'))
+    worker._swf.respond_activity_task_failed.assert_called_with(
+        taskToken=task_token, details='', reason='Failure!')
+    worker._swf.record_activity_task_heartbeat.assert_called_with(
+        taskToken=task_token, details='')
+
+
+def test_decider_class(poll_for_decision_task_response):
+    """Test Decider Worker class.
+    """
+
+    boto3.client = MagicMock()
+
+    decider = medium.Decider()
+
+    task_token = 'my_specific_task_token'
+    input_data = poll_for_decision_task_response
+    input_data['taskToken'] = task_token
+    decider._swf.poll_for_decision_task.return_value = input_data
+
+    decider.poll()
+    decider.complete()
+
+    decider._swf.respond_decision_task_completed.assert_called_with(
+        taskToken=task_token, decisions=None)
+    assert decider.last_tasktoken == 'my_specific_task_token'
+
+
+def test_actor_poll_without_tasklist_override():
+    """Test Actors behaviour without task list override.
+    """
+
+    boto3.client = MagicMock()
+
+    worker = medium.ActivityWorker(
+        name='test_name',
+        domain='test_domain',
+        task_list='test_task_list')
+    decider = medium.Decider(
+        name='test_name',
+        domain='test_domain',
+        task_list='test_task_list')
+    worker.poll()
+    decider.poll()
+    worker._swf.poll_for_activity_task.assert_called_with(
+        domain='test_domain', taskList={'name': 'test_task_list'})
+    decider._swf.poll_for_decision_task.assert_called_with(
+        domain='test_domain', taskList={'name': 'test_task_list'}, identity='')
+
+
+def test_worker_override_tasklist():
+    """Test ActivityWorker behaviour with task list override.
+    """
+
+    boto3.client = MagicMock()
+
+    worker = medium.ActivityWorker(
+        name='test_name',
+        domain='test_domain',
+        task_list='test_task_list')
+    worker.poll(task_list='some_other_tasklist')
+    worker._swf.poll_for_activity_task.assert_called_with(
+        domain='test_domain', taskList={'name': 'some_other_tasklist'})
+
+
+def test_decider_override_tasklist():
+    """Test Decider behaviour without task list override.
+    """
+
+    boto3.client = MagicMock()
+
+    decider = medium.Decider(
+        name='test_name',
+        domain='test_domain',
+        task_list='test_task_list')
+    decider.poll(task_list='some_other_tasklist')
+    decider._swf.poll_for_decision_task.assert_called_with(
+        domain='test_domain', taskList={'name': 'some_other_tasklist'},
+        identity='')
+
+
+def test_register_instance_with_given_method():
+    """Test Decider's instances registerer method.
+    """
+
+    boto3.client = MagicMock()
+
+    decider = medium.Decider()
+    method = MagicMock()
+    data = [{'some_key': 'some_data'}]
+    decider.register_instance_with_given_method(method, data)
+    method.assert_called_once_with(**data[0])
+
+
+def test_register_instance_with_given_method_exception():
+    """Test Decider's instances registerer method raising error.
+    """
+
+    boto3.client = MagicMock()
+
+    decider = medium.Decider()
+
+    method = MagicMock()
+    mocked_print = medium.print = MagicMock()
+    exception = ClientError(
+        error_response={
+            'Error': {
+                'Code': 'test_error_code',
+                'Message': 'test_error_message'
+            },
+        },
+        operation_name='test_operation')
+    method.side_effect = exception
+    data = [{'some_key': 'some_data'}]
+
+    decider.register_instance_with_given_method(method, data)
+    method.assert_called_with(**data[0])
+    mocked_print.assert_called_once_with(exception)
+
+
+def test_register(activity_object):
+    """Test Decider's instances registerer.
+    """
+
+    boto3.client = MagicMock()
+    medium.Decider.register_instance_with_given_method = MagicMock()
+
+    decider = medium.Decider(
+        name='test_name',
+        domain='test_domain',
+        version='test_version')
+    decider.activities = [activity_object, activity_object]
+
+    decider.register()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,8 @@ try:
     from unittest.mock import MagicMock
 except:
     from mock import MagicMock
-import boto.exception as boto_exception
 import datetime
 import pytest
-import json
 
 from garcon import utils
 
@@ -36,53 +34,3 @@ def test_create_dictionary_key():
 
     for value in values:
         assert len(utils.create_dictionary_key(value)) == 40
-
-def test_create_dictionary_key():
-    """Try creating a unique key from a dict.
-    """
-
-    values = [
-        dict(foo=10),
-        dict(foo2=datetime.datetime.now())]
-
-    for value in values:
-        assert len(utils.create_dictionary_key(value)) == 40
-
-
-def test_non_throttle_error():
-    """Assert SWF error is evaluated as non-throttle error properly.
-    """
-
-    response_status = 400
-    response_reason = 'Bad Request'
-    reponse_body = (
-        '{"__type": "com.amazon.coral.availability#ThrottlingException",'
-        '"message": "Rate exceeded"}')
-    json_body = json.loads(reponse_body)
-    exception = boto_exception.SWFResponseError(
-        response_status, response_reason, body=json_body)
-    result = utils.non_throttle_error(exception)
-    assert not utils.non_throttle_error(exception)
-
-    reponse_body = (
-        '{"__type": "com.amazon.coral.availability#OtheException",'
-        '"message": "Rate exceeded"}')
-    json_body = json.loads(reponse_body)
-    exception = boto_exception.SWFResponseError(
-        response_status, response_reason, body=json_body)
-    assert utils.non_throttle_error(exception)
-
-def test_throttle_backoff_handler():
-    """Assert backoff is logged correctly.
-    """
-
-    mock_activity = MagicMock()
-    details = dict(
-        args=(mock_activity,),
-        tries=5,
-        wait=10)
-    utils.throttle_backoff_handler(details)
-    mock_activity.logger.info.assert_called_with(
-        'Throttle Exception occurred on try {}. '
-        'Sleeping for {} seconds'.format(
-            details['tries'], details['wait']))


### PR DESCRIPTION
### Description of the Change
This change shifts version of the boto tool used in Garcon from boto2 to boto3. It makes backoff library usage unnecessary.

### Why Should This Be In Core?
Boto2 become obsolete and aren't supported by authors any more. Boto3 works with modern AWS SWF features.

### Possible Drawbacks
Boto3 doesn’t provide middle-level layer of the interface like the one that was in boto2. The missing layer was taken from boto2 to fulfill the gap between layers of the application and AWS API .

### Verification Process
I wrote a simple test workflow to prove that this feature works as described.

### Example
Since boto3 supports multiple retry on fail during poll procedure, all we need to do is config boto3 with wanted amount of retries.
```
from botocore.config import Config

config = Config(
    retries = dict(
        max_attempts=5
    )
)
creator = activity.create(domain=domain, name=name, config=config)
```